### PR TITLE
Rotate ONDC pre-prod encryption key in utilities; retire staging endpoints

### DIFF
--- a/utilities/on_subscibe-service/java/src/main/java/ondc/onboarding/utility/AppConfig.java
+++ b/utilities/on_subscibe-service/java/src/main/java/ondc/onboarding/utility/AppConfig.java
@@ -38,21 +38,22 @@ public class AppConfig {
 
     @Bean
     public String ondcPublicKey(){
-        return "MCowBQYDK2VuAyEAduMuZgmtpjdCuxv+Nc49K0cB6tL/Dj3HZetvVN7ZekM=";
+        return "MCowBQYDK2VuAyEARa/WcMCzNQp4DWjvTI4DK7vHL6EdaHqN4GjFIu9wxxM=";
     }
 
     @Bean
     public String gatewayUrl(){
-        return "https://staging.registry.ondc.org/subscribe";
+        // staging decommissioned -> defaulting to pre-prod
+        return "https://preprod.registry.ondc.org/ondc/subscribe";
     }
 
     @Bean
     public String vlookupUrl(){
-        //Staging
-        return "https://staging.registry.ondc.org/vlookup";
+        //Staging (decommissioned)
+        //return "https://staging.registry.ondc.org/vlookup";
 
-        //Preprod
-        //return "https://preprod.registry.ondc.org/ondc/vlookup";
+        //Preprod (vlookup is obsolete -> use /v2.0/lookup)
+        return "https://preprod.registry.ondc.org/v2.0/lookup";
 
         //Prod
         //return "https://prod.registry.ondc.org/vlookup";

--- a/utilities/on_subscibe-service/node/index.js
+++ b/utilities/on_subscibe-service/node/index.js
@@ -8,7 +8,7 @@ const port = 3000; // Port on which the server will listen
 const ENCRYPTION_PRIVATE_KEY =
   'MC4CAQEwBQYDK2VuBCIEILgcht9h660ZeO36tG+QuHGNcLN9JuAzxHWZl09f57Bh';
 const ONDC_PUBLIC_KEY =
-  'MCowBQYDK2VuAyEAlKHWJWiEiHFGlAJ6TE4VMGaeQUYg5DHEpuQdiq6flnQ=';
+  'MCowBQYDK2VuAyEARa/WcMCzNQp4DWjvTI4DK7vHL6EdaHqN4GjFIu9wxxM=';
 const REQUEST_ID = '6a6abf53-674f-4d6d-a52b-62e3fda55e04';
 const SIGNING_PRIVATE_KEY =
   '7M2L3q9y5gS/dq21Ly3Y3VtYEwgmGM1tM4n0wce/WgcJcOzvdfKo+AUEulIyQCawS39dc6uicu8NAaEpciPajg==';

--- a/utilities/on_subscibe-service/node/readme.md
+++ b/utilities/on_subscibe-service/node/readme.md
@@ -4,7 +4,7 @@
 1. Add following constants like below.
 
 - ENCRYPTION_PRIVATE_KEY = "NP's encryption private key"
-- ONDC_PUBLIC_KEY = "Registry's encryption public key as per your environment which is available in NP On-Boarding on [document](https://github.com/ONDC-Official/developer-docs/blob/main/registry/Onboarding%20of%20Participants.md) (staging key: MCowBQYDK2VuAyEAduMuZgmtpjdCuxv+Nc49K0cB6tL/Dj3HZetvVN7ZekM=)" 
+- ONDC_PUBLIC_KEY = "Registry's encryption public key as per your environment which is available in NP On-Boarding on [document](https://github.com/ONDC-Official/developer-docs/blob/main/registry/Onboarding%20of%20Participants.md) (pre-prod key: MCowBQYDK2VuAyEARa/WcMCzNQp4DWjvTI4DK7vHL6EdaHqN4GjFIu9wxxM=)" 
 - REQUEST_ID = "request_id which is sent in /subscribe"
 - SIGNING_PRIVATE_KEY = "NP's signing private key"
 

--- a/utilities/on_subscibe-service/php/src/index.php
+++ b/utilities/on_subscibe-service/php/src/index.php
@@ -5,7 +5,7 @@ use Sop\CryptoTypes\Asymmetric\OneAsymmetricKey;
 use Sop\CryptoTypes\Asymmetric\PublicKeyInfo;
 
 const ENCRYPTION_PRIVATE_KEY = "ENCRYPTION_PRIVATE_KEY";
-const ONDC_PUBLIC_KEY = "MCowBQYDK2VuAyEAduMuZgmtpjdCuxv+Nc49K0cB6tL/Dj3HZetvVN7ZekM=";
+const ONDC_PUBLIC_KEY = "MCowBQYDK2VuAyEARa/WcMCzNQp4DWjvTI4DK7vHL6EdaHqN4GjFIu9wxxM=";
 const REQUEST_ID = "REQUEST_ID";
 const SIGNING_PRIVATE_KEY = "SIGNING_PRIVATE_KEY";
 

--- a/utilities/on_subscibe-service/python/Latest/readme.md
+++ b/utilities/on_subscibe-service/python/Latest/readme.md
@@ -51,7 +51,7 @@ ENC_PRIVATE_KEY = "your-encryption-private-key"
 
 ## ONDC Subscribe API Endpoints
 
-### Staging Environment
+### Staging Environment (Decommissioned)
 `https://staging.registry.ondc.org/subscribe`
 
 ### Pre-Production Environment

--- a/utilities/on_subscibe-service/python/Legacy/Readme.md
+++ b/utilities/on_subscibe-service/python/Legacy/Readme.md
@@ -26,7 +26,7 @@ curl --location 'https://<Domain_Host_Url>/subscribe' \
     "<subscriber_id> | <ukId>": {
         "signingPublicKey": "...",
         "signingPrivateKey": "...",
-        "ondcPublicKey": "MCowBQYDK2VuAyEAduMuZgmtpjdCuxv+Nc49K0cB6tL/Dj3HZetvVN7ZekM=", # Change it for pre-prod and prod
+        "ondcPublicKey": "MCowBQYDK2VuAyEARa/WcMCzNQp4DWjvTI4DK7vHL6EdaHqN4GjFIu9wxxM=", # Change it for pre-prod and prod
         "encPublicKey": "...",
         "encPrivateKey": "...",
         "type": "BAP",
@@ -35,7 +35,7 @@ curl --location 'https://<Domain_Host_Url>/subscribe' \
     "<Domain_Host_Url>/dobpp/beckn/7f7896dd-787e-4a0b-8675-e9e6fe93bb8f | 50": {
         "signingPublicKey": "HUVYp98+DBp/LIbs7LoeSec3NwQcojLZhsa/tQdqbP4=",
         "signingPrivateKey": "...",
-        "ondcPublicKey": "MCowBQYDK2VuAyEAduMuZgmtpjdCuxv+Nc49K0cB6tL/Dj3HZetvVN7ZekM=",
+        "ondcPublicKey": "MCowBQYDK2VuAyEARa/WcMCzNQp4DWjvTI4DK7vHL6EdaHqN4GjFIu9wxxM=",
         "encPublicKey": "...",
         "encPrivateKey": "...",
         "type": "BPP",

--- a/utilities/signing_and_verification/python/cryptkey.py
+++ b/utilities/signing_and_verification/python/cryptkey.py
@@ -25,12 +25,12 @@ penkey = pkey.private_bytes(
 
 print("Local Private Key: ", base64.b64encode(penkey).decode('utf-8'))
 print("Local Public Key: ", base64.b64encode(uenkey).decode('utf-8'))
-print("ONDC Public Key: ", "MCowBQYDK2VuAyEAa9Wbpvd9SsrpOZFcynyt/TO3x0Yrqyys4NUGIvyxX2Q=")
+print("ONDC Public Key: ", "MCowBQYDK2VuAyEARa/WcMCzNQp4DWjvTI4DK7vHL6EdaHqN4GjFIu9wxxM=")
 
 myukey = base64.b64encode(uenkey).decode('utf-8')
 
 ondcpub = (base64.b64decode(
-    "MCowBQYDK2VuAyEAa9Wbpvd9SsrpOZFcynyt/TO3x0Yrqyys4NUGIvyxX2Q="))
+    "MCowBQYDK2VuAyEARa/WcMCzNQp4DWjvTI4DK7vHL6EdaHqN4GjFIu9wxxM="))
 oenkey = serialization.load_der_public_key(ondcpub)
 
 shared_key = pkey.exchange(oenkey)

--- a/utilities/signing_and_verification/python/scratch.py
+++ b/utilities/signing_and_verification/python/scratch.py
@@ -27,10 +27,10 @@ penkey = pkey.private_bytes(
 
 print("Local Private Key: ", base64.b64encode(penkey).decode('utf-8'))
 print("Local Public Key: ", base64.b64encode(uenkey).decode('utf-8'))
-print("ONDC Public Key: ", "MCowBQYDK2VuAyEAa9Wbpvd9SsrpOZFcynyt/TO3x0Yrqyys4NUGIvyxX2Q=")
+print("ONDC Public Key: ", "MCowBQYDK2VuAyEARa/WcMCzNQp4DWjvTI4DK7vHL6EdaHqN4GjFIu9wxxM=")
 
 myukey = base64.b64encode(uenkey).decode('utf-8')
-#"MCowBQYDK2VuAyEAa9Wbpvd9SsrpOZFcynyt/TO3x0Yrqyys4NUGIvyxX2Q=")
+#"MCowBQYDK2VuAyEARa/WcMCzNQp4DWjvTI4DK7vHL6EdaHqN4GjFIu9wxxM=")
 ondcpub = (base64.b64decode(
     "MCowBQYDK2VuAyEAF2efvGvniY1X7mVwjK+9z17pcrM+hnEYNUKiiUVSuyY="
     )

--- a/utilities/v2lookup utility/index.js
+++ b/utilities/v2lookup utility/index.js
@@ -7,10 +7,10 @@ import { hideBin } from 'yargs/helpers';
 const caller_subscriberId = process.env.SUBSCRIBER_ID || "<YOUR_SUBSCRIBER_ID>"; // Replace with your actual subscriber ID
 const uniqueKeyId = process.env.UNIQUE_KEY_ID || "<YOUR_UNIQUE_KEY_ID>"; // Replace with your actual unique key ID
 const privateKey = process.env.PRIVATE_KEY || "<YOUR_PRIVATE_KEY>"; // Replace with your actual private key
-const registryUrl = process.env.REGISTRY_URL || "https://staging.registry.ondc.org/v2.0/lookup";
+const registryUrl = process.env.REGISTRY_URL || "https://preprod.registry.ondc.org/v2.0/lookup"; // default was staging (decommissioned) -> now pre-prod
 
 // Registry URL for the ONDC registry
-// staging: https://staging.registry.ondc.org/v2.0/lookup
+// staging (decommissioned): https://staging.registry.ondc.org/v2.0/lookup
 // production: https://prod.registry.ondc.org/v2.0/lookup
 // preproduction: https://preprod.registry.ondc.org/v2.0/lookup
 

--- a/utilities/vlookup/node.js/README.md
+++ b/utilities/vlookup/node.js/README.md
@@ -37,7 +37,7 @@ Perform a VLookup operation by sending a POST request to `http://localhost:9900/
   "country": "IND", // country
   "type": "buyerApp", //buyerApp, sellerApp, gateway
   "city": "std:022", // city code
-  "env": "staging" //staging,preprod,prod
+  "env": "preprod" //preprod,prod (staging decommissioned)
 }
 ```
 

--- a/utilities/vlookup/node.js/index.js
+++ b/utilities/vlookup/node.js/index.js
@@ -16,7 +16,7 @@ const getEnvDetails = (env) => {
     envLink = "https://preprod.registry.ondc.org/ondc/vlookup";
   } else if (env === "prod") {
     envLink = "https://prod.registry.ondc.org/vlookup";
-  } else if (env === "staging") {
+  } else if (env === "staging") { // staging decommissioned — environment retired
     envLink = "https://staging.registry.ondc.org/vlookup";
   } else {
     throw new Error("Unsupported environment");

--- a/utilities/vlookup/python/README.md
+++ b/utilities/vlookup/python/README.md
@@ -37,7 +37,7 @@ Perform a VLookup operation by sending a POST request to `http://localhost:8000/
   "country": "IND", // country
   "type": "buyerApp", //buyerApp, sellerApp, gateway
   "city": "std:022", // city code
-  "env": "staging" //staging,preprod,prod
+  "env": "preprod" //preprod,prod (staging decommissioned)
 }
 ```
 

--- a/utilities/vlookup/python/utils.py
+++ b/utilities/vlookup/python/utils.py
@@ -23,7 +23,7 @@ def get_env_details(env):
         env_link = "https://preprod.registry.ondc.org/ondc/vlookup"
     elif env == "prod":
         env_link = "https://prod.registry.ondc.org/vlookup"
-    elif env == "staging":
+    elif env == "staging":  # staging decommissioned — environment retired
         env_link = "https://staging.registry.ondc.org/vlookup"
     else:
         raise ValueError("Unsupported environment")


### PR DESCRIPTION
## What
- Updates the hardcoded ONDC network **encryption public key** to the new **pre-prod** value in the `on_subscibe-service` samples (php, java, node, python Legacy) and the `signing_and_verification` python scripts.
- Repoints utilities that defaulted to the now-dead **staging** URL to **pre-prod** (`AppConfig.java` gatewayUrl/vlookupUrl, `v2lookup/index.js` default).
- Tags remaining staging references as **decommissioned** (`vlookup` py/node, on_subscibe python Latest readme).

## Why
Registry/gateway infrastructure migration — new pre-prod network key; staging environment retired.